### PR TITLE
feat(chat): Implement US10 - Bidirectional Admin-Patient Chat

### DIFF
--- a/src/app/communications/model/message.ts
+++ b/src/app/communications/model/message.ts
@@ -1,133 +1,96 @@
 export interface Message {
-  id: number;
-  sender: 'admin' | 'user';
-  receiverId: string;
-  from: string;
-  to: string;
+  sender: string; // email o tipo: 'admin' o 'paciente'
+  receiver: string; // destino del mensaje
   content: string;
   timestamp: string;
-  file?: {
-    name: string;
-    url: string;
-  };
+  file?: { name: string; url: string }; // opcional
 }
+
+// Nota: Los mockMessages se actualizan para reflejar la nueva estructura.
+// Se asume que 'sender' y 'receiver' ahora almacenarán identificadores como emails.
+// El campo 'id' se ha eliminado según la nueva especificación.
+// Los campos 'receiverId', 'from', 'to' han sido reemplazados por 'receiver'.
 const mockMessages: Message[] = [
   // Pedro Sanchez – TCK-004
   {
-    id: 1001,
-    sender: 'user',
-    receiverId: 'admin@hormonalcare.com',
-    from: 'pedro@patient.hormonalcare.com',
-    to: 'admin@hormonalcare.com',
+    sender: 'pedro@patient.hormonalcare.com', // Anteriormente 'user', 'from'
+    receiver: 'admin@hormonalcare.com',      // Anteriormente 'admin', 'to', 'receiverId'
     content: 'Hi, I’m not getting my medication reminders.',
     timestamp: '2025-06-10T15:21:00Z'
   },
   {
-    id: 1002,
-    sender: 'admin',
-    receiverId: 'pedro@patient.hormonalcare.com',
-    from: 'admin@hormonalcare.com',
-    to: 'pedro@patient.hormonalcare.com',
+    sender: 'admin@hormonalcare.com',        // Anteriormente 'admin', 'from'
+    receiver: 'pedro@patient.hormonalcare.com', // Anteriormente 'user', 'to', 'receiverId'
     content: 'We’re checking your reminder configuration. Thanks!',
     timestamp: '2025-06-10T15:25:00Z'
   },
 
-  // Dr. Laura Martinez – TCK-005
+  // Dr. Laura Martinez – TCK-005 (Asumiendo que un doctor también puede chatear con admin)
   {
-    id: 1003,
-    sender: 'user',
-    receiverId: 'admin@hormonalcare.com',
-    from: 'laura@doctor.hormonalcare.com',
-    to: 'admin@hormonalcare.com',
+    sender: 'laura@doctor.hormonalcare.com',
+    receiver: 'admin@hormonalcare.com',
     content: 'My patient history page shows blank.',
     timestamp: '2025-06-12T08:46:00Z'
   },
   {
-    id: 1004,
-    sender: 'admin',
-    receiverId: 'laura@doctor.hormonalcare.com',
-    from: 'admin@hormonalcare.com',
-    to: 'laura@doctor.hormonalcare.com',
+    sender: 'admin@hormonalcare.com',
+    receiver: 'laura@doctor.hormonalcare.com',
     content: 'Could you share a screenshot of the issue?',
     timestamp: '2025-06-12T08:47:00Z'
   },
 
   // Marco Rojas – TCK-006
   {
-    id: 1005,
-    sender: 'user',
-    receiverId: 'admin@hormonalcare.com',
-    from: 'marco@patient.hormonalcare.com',
-    to: 'admin@hormonalcare.com',
+    sender: 'marco@patient.hormonalcare.com',
+    receiver: 'admin@hormonalcare.com',
     content: 'App crashes every time after login.',
     timestamp: '2025-06-01T12:11:00Z'
   },
   {
-    id: 1006,
-    sender: 'admin',
-    receiverId: 'marco@patient.hormonalcare.com',
-    from: 'admin@hormonalcare.com',
-    to: 'marco@patient.hormonalcare.com',
+    sender: 'admin@hormonalcare.com',
+    receiver: 'marco@patient.hormonalcare.com',
     content: 'Thanks Marco, we’ll release a fix in the next update.',
     timestamp: '2025-06-01T12:15:00Z'
   },
 
   // Dr. Andrea Paredes – TCK-007
   {
-    id: 1007,
-    sender: 'user',
-    receiverId: 'admin@hormonalcare.com',
-    from: 'andrea@doctor.hormonalcare.com',
-    to: 'admin@hormonalcare.com',
+    sender: 'andrea@doctor.hormonalcare.com',
+    receiver: 'admin@hormonalcare.com',
     content: 'Lab results won’t open for patient #4532.',
     timestamp: '2025-06-13T17:02:00Z'
   },
   {
-    id: 1008,
-    sender: 'admin',
-    receiverId: 'andrea@doctor.hormonalcare.com',
-    from: 'admin@hormonalcare.com',
-    to: 'andrea@doctor.hormonalcare.com',
+    sender: 'admin@hormonalcare.com',
+    receiver: 'andrea@doctor.hormonalcare.com',
     content: 'We’re checking access permissions for that lab report.',
     timestamp: '2025-06-13T17:06:00Z'
   },
 
   // Lucia Fernandez – TCK-008
   {
-    id: 1009,
-    sender: 'user',
-    receiverId: 'admin@hormonalcare.com',
-    from: 'lucia@patient.hormonalcare.com',
-    to: 'admin@hormonalcare.com',
+    sender: 'lucia@patient.hormonalcare.com',
+    receiver: 'admin@hormonalcare.com',
     content: 'No doctor is listed on my profile page.',
     timestamp: '2025-06-05T09:31:00Z'
   },
   {
-    id: 1010,
-    sender: 'admin',
-    receiverId: 'lucia@patient.hormonalcare.com',
-    from: 'admin@hormonalcare.com',
-    to: 'lucia@patient.hormonalcare.com',
+    sender: 'admin@hormonalcare.com',
+    receiver: 'lucia@patient.hormonalcare.com',
     content: 'We’ve assigned Dr. Laura Martinez to you.',
     timestamp: '2025-06-05T09:33:00Z'
   },
 
   // Dr. Rafael Castillo – TCK-009
   {
-    id: 1011,
-    sender: 'user',
-    receiverId: 'admin@hormonalcare.com',
-    from: 'rafael@doctor.hormonalcare.com',
-    to: 'admin@hormonalcare.com',
+    sender: 'rafael@doctor.hormonalcare.com',
+    receiver: 'admin@hormonalcare.com',
     content: 'Platform gets very slow during virtual consults.',
     timestamp: '2025-06-14T20:01:00Z'
   },
   {
-    id: 1012,
-    sender: 'admin',
-    receiverId: 'rafael@doctor.hormonalcare.com',
-    from: 'admin@hormonalcare.com',
-    to: 'rafael@doctor.hormonalcare.com',
+    sender: 'admin@hormonalcare.com',
+    receiver: 'rafael@doctor.hormonalcare.com',
     content: 'Thanks for reporting. We’re monitoring server usage.',
     timestamp: '2025-06-14T20:05:00Z'
   }

--- a/src/app/pages/patient-chat/patient-chat.component.css
+++ b/src/app/pages/patient-chat/patient-chat.component.css
@@ -1,0 +1,196 @@
+/* Estilos para el contenedor principal del chat del paciente */
+.patient-chat-container {
+  display: flex;
+  flex-direction: column; /* El header estará arriba del chat window */
+  height: 100%; /* Ocupa toda la altura disponible */
+  background-color: #f9f9f9; /* Un fondo ligeramente diferente para distinguir */
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden; /* Para que los bordes redondeados afecten a los hijos */
+}
+
+/* Estilos para el encabezado del chat */
+.chat-header {
+  padding: 12px 20px;
+  background-color: #7c3aed; /* Morado de HormonalCare */
+  color: white;
+  border-bottom: 1px solid #6a2dbd;
+  text-align: center; /* Centrar el nombre del interlocutor */
+}
+
+.chat-header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+/* Estilos para la ventana de chat (similar al admin) */
+.chat-window {
+  flex: 1; /* Ocupa el espacio restante */
+  padding: 15px; /* Un poco menos de padding que el admin */
+  display: flex;
+  flex-direction: column;
+  background-color: #fff; /* Fondo blanco para la ventana de mensajes */
+  overflow-y: hidden; /* El scroll lo maneja .messages */
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto; /* Habilitar scroll para mensajes */
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px; /* Espacio entre burbujas */
+  padding-right: 8px; /* Espacio para la barra de scroll */
+  scroll-behavior: smooth;
+}
+
+/* Estilos para cada mensaje (comunes para admin y paciente) */
+.message {
+  display: flex;
+  align-items: flex-start; /* Alinea avatar con la parte superior de la burbuja */
+  max-width: 75%; /* Limita el ancho de los mensajes */
+}
+
+/* Mensajes del usuario actual (paciente) - clase 'user' */
+.message.user {
+  align-self: flex-end; /* Alinea a la derecha */
+}
+.message.user .bubble {
+  background-color: #d0ebff; /* Azul claro, como en el chat del admin */
+  border-top-right-radius: 0; /* Esquina para indicar que es enviado */
+  margin-right: 8px; /* Espacio del avatar */
+}
+.message.user .avatar {
+  order: 1; /* Mueve el avatar a la derecha de la burbuja */
+  margin-left: 8px;
+  margin-right: 0;
+}
+
+
+/* Mensajes del interlocutor (admin) - clase 'admin' */
+.message.admin {
+  align-self: flex-start; /* Alinea a la izquierda */
+}
+.message.admin .bubble {
+  background-color: #e8cbfb; /* Lila, como en el chat del admin */
+  border-top-left-radius: 0; /* Esquina para indicar que es recibido */
+  margin-left: 8px; /* Espacio del avatar */
+}
+.message.admin .avatar {
+  margin-right: 8px;
+}
+
+
+/* Estilos para la burbuja del mensaje */
+.bubble {
+  padding: 10px 15px;
+  border-radius: 18px; /* Burbujas más redondeadas */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  position: relative;
+  word-wrap: break-word; /* Para que el texto largo no rompa el layout */
+}
+
+.bubble p {
+  margin: 0 0 4px 0; /* Espacio debajo del contenido principal */
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.bubble strong {
+  font-size: 0.8rem; /* Nombre del remitente un poco más pequeño */
+  color: #333;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.bubble small.timestamp {
+  display: block;
+  margin-top: 5px;
+  font-size: 0.7rem;
+  color: #777; /* Color más sutil para el timestamp */
+  text-align: right;
+}
+
+/* Estilos para el avatar */
+.avatar {
+  width: 36px; /* Avatar ligeramente más grande */
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid #eee; /* Borde sutil para el avatar */
+}
+
+/* Área de entrada de texto */
+.input-area {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 0; /* Padding vertical, horizontal se maneja en chat-window */
+  border-top: 1px solid #e0e0e0; /* Separador más sutil */
+}
+
+.input-area input[type="text"] {
+  flex: 1;
+  padding: 12px 16px; /* Input más grande */
+  border: 1px solid #ccc;
+  border-radius: 22px; /* Input más redondeado */
+  outline: none;
+  font-size: 0.95rem;
+  transition: border-color 0.2s;
+}
+.input-area input[type="text"]:focus {
+  border-color: #7c3aed; /* Color de borde al enfocar */
+}
+
+/* Estilos para el botón de adjuntar archivo y enviar (reutiliza mat-icon) */
+.file-upload-button, .input-area button[mat-icon-button] {
+  color: #7c3aed; /* Color principal para iconos de acción */
+}
+.input-area button[mat-icon-button]:hover {
+  color: #5a21ab; /* Color más oscuro en hover */
+}
+
+
+/* Estilos para archivos adjuntos (consistente con admin chat) */
+.attachment-container {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background-color: rgba(0, 0, 0, 0.03); /* Fondo muy sutil */
+  border-radius: 8px;
+  display: inline-block;
+  max-width: 100%;
+  border: 1px solid rgba(0,0,0,0.05);
+}
+
+.attachment-container a {
+  color: #7c3aed;
+  text-decoration: none;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  max-width: 100%;
+  font-size: 0.85rem;
+}
+.attachment-container a:hover {
+  text-decoration: underline;
+  color: #5a21ab;
+}
+
+/* Responsive (opcional, si se requiere un diseño específico para móviles) */
+@media (max-width: 600px) {
+  .chat-window {
+    padding: 10px;
+  }
+  .message {
+    max-width: 90%; /* Mensajes pueden ser más anchos en pantallas pequeñas */
+  }
+  .bubble {
+    padding: 8px 12px;
+  }
+  .input-area input[type="text"] {
+    padding: 10px 14px;
+  }
+}

--- a/src/app/pages/patient-chat/patient-chat.component.html
+++ b/src/app/pages/patient-chat/patient-chat.component.html
@@ -1,28 +1,22 @@
-<div class="live-chat-container">
-  <!-- Usuario seleccionado -->
-  <ul class="user-list">
-    <li>
-      <mat-icon>person</mat-icon>
-      {{ selectedUser.name }} {{ selectedUser.lastname }}
-    </li>
-  </ul>
+<div class="patient-chat-container">
+  <!-- Encabezado del chat con el nombre del interlocutor (Admin) -->
+  <section class="chat-header">
+    <h4>Chat con {{ chatPartner.name }}</h4>
+  </section>
 
   <!-- Ventana del chat -->
-  <section class="chat-window" *ngIf="true">
-    <h4>Chat con {{ selectedUser.name }} {{ selectedUser.lastname }}</h4>
-
+  <section class="chat-window">
     <!-- Lista de mensajes -->
     <div class="messages chat-messages" #chatMessagesContainer>
-      <!-- Usar adminEmail y selectedUser.email para determinar el origen del mensaje -->
-      <div *ngFor="let msg of messages" class="message" [ngClass]="msg.sender === adminEmail ? 'admin' : 'user'">
+      <div *ngFor="let msg of messages" class="message" [ngClass]="isMyMessage(msg) ? 'user' : 'admin'">
+        <!-- El remitente del mensaje determina el avatar y nombre a mostrar -->
         <img
-          [src]="msg.sender === adminEmail ? 'assets/admin-avatar.png' : selectedUser.image"
+          [src]="isMyMessage(msg) ? currentUser.avatar : chatPartner.avatar"
           class="avatar"
           alt="avatar"
         />
-
         <div class="bubble">
-          <strong>{{ msg.sender === adminEmail ? 'Admin' : selectedUser.name }}:</strong>
+          <strong>{{ isMyMessage(msg) ? currentUser.name : chatPartner.name }}:</strong>
           <p *ngIf="msg.content">{{ msg.content }}</p>
 
           <!-- Archivo adjunto -->
@@ -31,13 +25,12 @@
               📎 {{ msg.file.name }}
             </a>
           </div>
-
           <small class="timestamp">{{ msg.timestamp | date: 'short' }}</small>
         </div>
       </div>
     </div>
 
-    <!-- Área de entrada -->
+    <!-- Área de entrada de mensajes -->
     <div class="input-area">
       <input
         type="text"
@@ -46,14 +39,13 @@
         (keydown.enter)="sendMessage()"
         autofocus
       />
-
-      <!-- Cargar archivo -->
-      <label>
+      <!-- Botón para adjuntar archivo -->
+      <label class="file-upload-button">
         <input type="file" (change)="handleFileUpload($event)" hidden multiple />
         <mat-icon>attach_file</mat-icon>
       </label>
-
-      <button mat-icon-button (click)="sendMessage()" [disabled]="!newMessage.trim() && uploadedFiles.length === 0">
+      <!-- Botón para enviar mensaje -->
+      <button mat-icon-button color="primary" (click)="sendMessage()" [disabled]="!newMessage.trim() && uploadedFiles.length === 0">
         <mat-icon>send</mat-icon>
       </button>
     </div>

--- a/src/app/pages/patient-chat/patient-chat.component.ts
+++ b/src/app/pages/patient-chat/patient-chat.component.ts
@@ -1,0 +1,186 @@
+import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule, DatePipe, NgFor, NgIf, NgClass } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon'; // Importar MatIconModule
+import { MatButtonModule } from '@angular/material/button'; // Importar MatButtonModule
+
+import { Message } from '../../communications/model/message'; // Ajustar ruta si es necesario
+
+// Interfaz para el usuario del chat (simplificada para el paciente)
+interface ChatParticipant {
+  name: string;
+  email: string;
+  avatar: string;
+}
+
+@Component({
+  selector: 'app-patient-chat',
+  standalone: true,
+  templateUrl: './patient-chat.component.html',
+  styleUrls: ['./patient-chat.component.css'], // Crear este archivo después
+  imports: [
+    CommonModule,
+    FormsModule,
+    NgFor,
+    NgIf,
+    NgClass,
+    DatePipe,
+    MatIconModule, // Añadir MatIconModule a imports
+    MatButtonModule  // Añadir MatButtonModule a imports
+  ]
+})
+export class PatientChatComponent implements OnInit, OnDestroy {
+  // Identificadores de usuario y clave de localStorage (deben ser los mismos que en admin)
+  readonly adminEmail = 'admin@hormonalcare.com';
+  readonly patientEmail = 'patient@hormonalcare.com'; // Email de este paciente
+  readonly chatStorageKey = 'chat_admin_paciente';
+
+  // Información del usuario actual (paciente) y del interlocutor (admin)
+  currentUser: ChatParticipant = {
+    name: 'Paciente Demo', // Nombre del paciente actual
+    email: this.patientEmail,
+    avatar: 'assets/user-avatar.png' // Avatar del paciente
+  };
+
+  chatPartner: ChatParticipant = {
+    name: 'Soporte Admin', // Nombre del administrador
+    email: this.adminEmail,
+    avatar: 'assets/admin-avatar.png' // Avatar del administrador
+  };
+
+  messages: Message[] = [];
+  newMessage = '';
+  uploadedFiles: { name: string; url: string; type?: string }[] = [];
+
+  private messagePollingInterval: any;
+  @ViewChild('chatMessagesContainer') private chatMessagesContainer!: ElementRef;
+
+  constructor() {}
+
+  ngOnInit(): void {
+    this.loadMessages();
+    this.messagePollingInterval = setInterval(() => {
+      this.loadMessages();
+    }, 1000); // Revisa nuevos mensajes cada segundo
+
+    // Opcional: Cargar mensajes de prueba si el chat está vacío.
+    // Esto podría ser redundante si el admin chat component ya lo hace.
+    // Se puede comentar o ajustar si es necesario.
+    this.initializeMockMessagesIfEmpty();
+  }
+
+  ngOnDestroy(): void {
+    if (this.messagePollingInterval) {
+      clearInterval(this.messagePollingInterval);
+    }
+  }
+
+  private scrollToBottom(): void {
+    try {
+      if (this.chatMessagesContainer) {
+        this.chatMessagesContainer.nativeElement.scrollTop = this.chatMessagesContainer.nativeElement.scrollHeight;
+      }
+    } catch (err) {
+      console.error('Error scrolling to bottom:', err);
+    }
+  }
+
+  private loadMessages(): void {
+    const storedMessages = localStorage.getItem(this.chatStorageKey);
+    const currentMessages = storedMessages ? JSON.parse(storedMessages) : [];
+
+    // Mostrar todos los mensajes ya que la clave es específica para esta conversación.
+    // No se requiere filtrado adicional basado en sender/receiver aquí,
+    // ya que se asume que chatStorageKey solo contiene mensajes entre este paciente y el admin.
+    if (JSON.stringify(this.messages) !== JSON.stringify(currentMessages)) {
+      this.messages = currentMessages;
+      setTimeout(() => this.scrollToBottom(), 0);
+    }
+  }
+
+  private initializeMockMessagesIfEmpty(): void {
+    const existingMessages = localStorage.getItem(this.chatStorageKey);
+    if (!existingMessages || JSON.parse(existingMessages).length === 0) {
+      // Solo añade mensajes si está completamente vacío, para evitar duplicados
+      // si el admin component también tiene una función similar.
+      const mockMessages: Message[] = [
+        {
+          sender: this.patientEmail,
+          receiver: this.adminEmail,
+          content: 'Hola Admin, tengo una pregunta rápida.',
+          timestamp: new Date(Date.now() - 60000 * 2).toISOString()
+        },
+        {
+          sender: this.adminEmail,
+          receiver: this.patientEmail,
+          content: 'Hola Paciente Demo, dime en qué puedo ayudarte.',
+          timestamp: new Date(Date.now() - 60000 * 1).toISOString()
+        }
+      ];
+      localStorage.setItem(this.chatStorageKey, JSON.stringify(mockMessages));
+      this.loadMessages();
+    }
+  }
+
+  handleFileUpload(event: any): void {
+    const files: FileList = event.target.files;
+    for (let i = 0; i < files.length; i++) {
+      const file = files.item(i);
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = (e: any) => {
+          this.uploadedFiles.push({
+            name: file.name,
+            url: e.target.result
+          });
+        };
+        reader.readAsDataURL(file);
+      }
+    }
+  }
+
+  sendMessage(): void {
+    const trimmedMessageContent = this.newMessage.trim();
+    if (!trimmedMessageContent && this.uploadedFiles.length === 0) {
+      return;
+    }
+
+    const currentMessages: Message[] = JSON.parse(localStorage.getItem(this.chatStorageKey) || '[]');
+    const timestamp = new Date().toISOString();
+
+    if (trimmedMessageContent) {
+      const textMessage: Message = {
+        sender: this.currentUser.email, // Paciente es el emisor
+        receiver: this.chatPartner.email, // Admin es el receptor
+        content: trimmedMessageContent,
+        timestamp: timestamp
+      };
+      currentMessages.push(textMessage);
+    }
+
+    this.uploadedFiles.forEach(file => {
+      const fileMessage: Message = {
+        sender: this.currentUser.email,
+        receiver: this.chatPartner.email,
+        content: '', // Puede estar vacío si solo es un archivo
+        timestamp: timestamp,
+        file: {
+          name: file.name,
+          url: file.url
+        }
+      };
+      currentMessages.push(fileMessage);
+    });
+
+    localStorage.setItem(this.chatStorageKey, JSON.stringify(currentMessages));
+    this.messages = [...currentMessages];
+    this.newMessage = '';
+    this.uploadedFiles = [];
+    setTimeout(() => this.scrollToBottom(), 0);
+  }
+
+  // Helper para la plantilla para determinar si el mensaje es del usuario actual (paciente)
+  isMyMessage(message: Message): boolean {
+    return message.sender === this.currentUser.email;
+  }
+}


### PR DESCRIPTION
Implementa un chat funcional y bidireccional entre un paciente simulado (en src/app/pages/patient-chat) y el administrador (en src/app/admin/pages/support/components/live-chat).

Utiliza localStorage con una clave compartida ('chat_admin_paciente') para la persistencia y simulación de comunicación en tiempo real.

Cambios principales:
- Actualizado el modelo Message (message.ts) a la nueva especificación (sender: string, receiver: string).
- Modificado live-chat.component (admin) para usar la clave compartida y el nuevo modelo Message.
- Creado patient-chat.component (paciente) con lógica y UI para chatear con el admin, usando la misma clave compartida y modelo.
- Ambos componentes muestran mensajes diferenciados (avatar, nombre, color) y soportan envío de texto y archivos.
- Estilos CSS creados/ajustados para ambas vistas, buscando coherencia visual.