### PR TITLE
fix(chat): Apply US10 corrections and model updates

### DIFF
--- a/src/app/admin/pages/support/components/live-chat/live-chat.component.ts
+++ b/src/app/admin/pages/support/components/live-chat/live-chat.component.ts
@@ -50,7 +50,7 @@ export class LiveChatComponent implements OnInit, OnDestroy {
 
   readonly adminEmail = 'admin@hormonalcare.com'; // Email del administrador
   readonly patientEmail = 'patient@hormonalcare.com'; // Email del paciente (coincide con selectedUser.email)
-  readonly chatStorageKey = 'chat_admin_paciente'; // Clave compartida
+  readonly chatStorageKey = 'shared_chat_messages'; // Clave compartida actualizada
 
   messages: Message[] = [];
   newMessage = '';

--- a/src/app/admin/pages/support/components/reply-dialog/reply-dialog.component.ts
+++ b/src/app/admin/pages/support/components/reply-dialog/reply-dialog.component.ts
@@ -46,15 +46,14 @@ export class ReplyDialogComponent {
   sendReply(): void {
     if (this.replyMessage.trim()) {
       const message: Message = {
-        id: Date.now(),
-        sender: 'admin',
-        receiverId: this.data.userEmail,
-        from: 'admin@hormonalcare.com',
-        to: this.data.userEmail,
+        id: Date.now().toString(), // ID como string
+        sender: 'admin@hormonalcare.com', // Usar email completo para sender
+        receiver: this.data.userEmail,   // Usar receiver
         content: this.replyMessage.trim(),
         timestamp: new Date().toISOString()
       };
 
+      // Asumiendo que chatService.sendMessage espera el modelo Message actualizado
       this.chatService.sendMessage(message).subscribe(() => {
         this.dialogRef.close(this.replyMessage); // opcional: puedes pasar mensaje como respuesta
       });

--- a/src/app/admin/pages/support/components/ticket-list/ticket-list.component.ts
+++ b/src/app/admin/pages/support/components/ticket-list/ticket-list.component.ts
@@ -190,15 +190,14 @@ export class TicketListComponent implements OnInit, AfterViewInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result?.message && ticket.userEmail) {
         const newMessage: Message = {
-          id: Date.now(),
-          sender: 'admin',
-          receiverId: ticket.userEmail,
-          from: 'admin@hormonalcare.com',
-          to: ticket.userEmail,
+          id: Date.now().toString(), // ID como string
+          sender: 'admin@hormonalcare.com', // Usar email completo para sender
+          receiver: ticket.userEmail,   // Usar receiver
           content: result.message,
           timestamp: new Date().toISOString()
         };
 
+        // Asumiendo que chatService.sendMessage espera el modelo Message actualizado
         this.chatService.sendMessage(newMessage).subscribe(() => {
           const [first, last] = ticket.userName.trim().split(' ');
           const profile: DoctorProfile = {

--- a/src/app/communications/components/chat-with-other-users/chat.component.html
+++ b/src/app/communications/components/chat-with-other-users/chat.component.html
@@ -6,8 +6,8 @@
     <div *ngFor="let message of messages" class="message-container">
       <div [ngClass]="{
             'message': true,
-            'message-received': message.from !== currentUser.email,
-            'message-sent': message.from === currentUser.email
+            'message-received': message.sender !== currentUser.email,
+            'message-sent': message.sender === currentUser.email
           }">
         <p>{{ message.content }}</p>
         <span>{{ message.timestamp | date:'shortTime' }}</span>

--- a/src/app/communications/model/message.ts
+++ b/src/app/communications/model/message.ts
@@ -4,6 +4,7 @@ export interface Message {
   content: string;
   timestamp: string;
   file?: { name: string; url: string }; // opcional
+  id?: string; // Añadido según especificación de corrección
 }
 
 // Nota: Los mockMessages se actualizan para reflejar la nueva estructura.

--- a/src/app/communications/services/chat.service.ts
+++ b/src/app/communications/services/chat.service.ts
@@ -27,19 +27,19 @@ export class ChatService {
     );
   }
 
-  getMessages(from: string, to: string): Observable<Message[]> {
+  getMessages(senderParam: string, receiverParam: string): Observable<Message[]> {
     return this.http.get<Message[]>(`${this.apiUrl}/messages?_sort=timestamp&_order=asc`).pipe(
       map(messages =>
         messages.filter(
-          message =>
-            (message.from === from && message.to === to) ||
-            (message.from === to && message.to === from)
+          msg => // Asumiendo que msg (Message) ahora tiene sender y receiver
+            (msg.sender === senderParam && msg.receiver === receiverParam) ||
+            (msg.sender === receiverParam && msg.receiver === senderParam)
         )
       )
     );
   }
 
-  sendMessage(message: Message): Observable<Message> {
+  sendMessage(message: Message): Observable<Message> { // message ya debería tener sender/receiver
     return this.http.post<Message>(`${this.apiUrl}/messages`, message);
   }
 

--- a/src/app/pages/patient-chat/patient-chat.component.ts
+++ b/src/app/pages/patient-chat/patient-chat.component.ts
@@ -33,7 +33,7 @@ export class PatientChatComponent implements OnInit, OnDestroy {
   // Identificadores de usuario y clave de localStorage (deben ser los mismos que en admin)
   readonly adminEmail = 'admin@hormonalcare.com';
   readonly patientEmail = 'patient@hormonalcare.com'; // Email de este paciente
-  readonly chatStorageKey = 'chat_admin_paciente';
+  readonly chatStorageKey = 'shared_chat_messages'; // Clave compartida actualizada
 
   // Información del usuario actual (paciente) y del interlocutor (admin)
   currentUser: ChatParticipant = {


### PR DESCRIPTION
- Updated Message model to include optional `id: string`.
- Corrected "id no existe" errors in `reply-dialog.component.ts` and `ticket-list.component.ts` by assigning `Date.now().toString()` to `id`.
- Replaced deprecated `from`/`to` properties with `sender`/`receiver` in `chat.service.ts` (getMessages method) and `chat.component.html` (ngClass conditions).
- Ensured `reply-dialog.component.ts` and `ticket-list.component.ts` now construct messages with `sender` (admin email) and `receiver` (user email) when interacting with ChatService.
- Updated localStorage key to `shared_chat_messages` for the admin-patient chat in `live-chat.component.ts` and `patient-chat.component.ts`.

These changes address compilation errors and align the specified components with the updated Message model structure, while adhering to the constraint of not directly modifying the patient-doctor chat flow beyond the service and generic component updates requested.